### PR TITLE
remove http prefix

### DIFF
--- a/CONICSmat/R/GetPositions.R
+++ b/CONICSmat/R/GetPositions.R
@@ -10,11 +10,11 @@
 
 getGenePositions= function(gene_names,ensembl_version="dec2016.archive.ensembl.org",species="human"){
   if (species=="human"){
-	ensembl = biomaRt::useMart(biomart = "ENSEMBL_MART_ENSEMBL", dataset = "hsapiens_gene_ensembl", host=paste("http://",ensembl_version,sep=""))
+	ensembl = biomaRt::useMart(biomart = "ENSEMBL_MART_ENSEMBL", dataset = "hsapiens_gene_ensembl", host=ensembl_version)
 	gene_positions <- biomaRt::getBM(attributes=c('ensembl_gene_id','hgnc_symbol','chromosome_name','start_position','end_position'), filters ='hgnc_symbol', values =gene_names, mart = ensembl)
   }
   else {
-	ensembl = biomaRt::useMart(biomart = "ENSEMBL_MART_ENSEMBL", dataset = "mmusculus_gene_ensembl", host=paste("http://",ensembl_version,sep=""))
+	ensembl = biomaRt::useMart(biomart = "ENSEMBL_MART_ENSEMBL", dataset = "mmusculus_gene_ensembl", host=ensembl_version)
 	gene_positions <- biomaRt::getBM(attributes=c('ensembl_gene_id','mgi_symbol','chromosome_name','start_position','end_position'), filters ='mgi_symbol', values =gene_names, mart = ensembl)
   }
   gene_positions=gene_positions[!duplicated(gene_positions[,2]),]


### PR DESCRIPTION
In my hands (R 3.4.1, CONICSmat_0.0.0.1), these http prefixes cause the following error:

```
Request to BioMart web service failed.
The BioMart web service you're accessing may be down.
Check the following URL and see if this website is available:
http://http://dec2016.archive.ensembl.org:80/biomart/martservice?type=registry&requestid=biomaRt
Error in if (!grepl(x = registry, pattern = "^\n*<MartRegistry>")) { :
  argument is of length zero
```

Dropping the http fixes that issue